### PR TITLE
feat: implement Select tool for dragging and resizing elements

### DIFF
--- a/prompts/2025-06-01-06-45-38_implementSelectDrag.txt
+++ b/prompts/2025-06-01-06-45-38_implementSelectDrag.txt
@@ -1,0 +1,12 @@
+For this next iteration, let's make the Select button work for dragging and resizing elements. Please implement the following features, using separate git commits to logically separate your code changes.
+
+When Select button is active, the user can drag elements around on the canvas as follows:
+
+1. Wheel movement / scaling logic:
+    - Drag a wheel's interior to reposition it.
+    - Drag a wheel's edge to change its radius.
+2. Rod movement / scaling logic:
+    - Drag the end of a rod to change ONLY that endpoint -- the Rod's other endpoint stays fixed.
+    - Drag the middle of a rod to reposition it.
+3. Pivot movement logic:
+    - Drag a Pivot to reposition it. 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,24 +32,30 @@ function App() {
     setPivots(prev => [pivot, ...prev])
   }
 
-  const handleUpdateWheel = (wheel: Wheel) => {
-    const message = `Update Wheel at (${wheel.center.x.toFixed(1)}, ${wheel.center.y.toFixed(1)})`;
-    console.log(message);
-    setHistory(prev => [{ message, timestamp: new Date() }, ...prev]);
+  const handleUpdateWheel = (wheel: Wheel, isDragComplete: boolean = false) => {
+    if (isDragComplete) {
+      const message = `Update Wheel at (${wheel.center.x.toFixed(1)}, ${wheel.center.y.toFixed(1)})`;
+      console.log(message);
+      setHistory(prev => [{ message, timestamp: new Date() }, ...prev]);
+    }
     setWheels(prev => prev.map(w => w.id === wheel.id ? wheel : w));
   }
 
-  const handleUpdateRod = (rod: Rod) => {
-    const message = `Update Rod from (${rod.start.x.toFixed(1)}, ${rod.start.y.toFixed(1)}) to (${rod.end.x.toFixed(1)}, ${rod.end.y.toFixed(1)})`;
-    console.log(message);
-    setHistory(prev => [{ message, timestamp: new Date() }, ...prev]);
+  const handleUpdateRod = (rod: Rod, isDragComplete: boolean = false) => {
+    if (isDragComplete) {
+      const message = `Update Rod from (${rod.start.x.toFixed(1)}, ${rod.start.y.toFixed(1)}) to (${rod.end.x.toFixed(1)}, ${rod.end.y.toFixed(1)})`;
+      console.log(message);
+      setHistory(prev => [{ message, timestamp: new Date() }, ...prev]);
+    }
     setRods(prev => prev.map(r => r.id === rod.id ? rod : r));
   }
 
-  const handleUpdatePivot = (pivot: Pivot) => {
-    const message = `Update Pivot at (${pivot.position.x.toFixed(1)}, ${pivot.position.y.toFixed(1)})`;
-    console.log(message);
-    setHistory(prev => [{ message, timestamp: new Date() }, ...prev]);
+  const handleUpdatePivot = (pivot: Pivot, isDragComplete: boolean = false) => {
+    if (isDragComplete) {
+      const message = `Update Pivot at (${pivot.position.x.toFixed(1)}, ${pivot.position.y.toFixed(1)})`;
+      console.log(message);
+      setHistory(prev => [{ message, timestamp: new Date() }, ...prev]);
+    }
     setPivots(prev => prev.map(p => p.id === pivot.id ? pivot : p));
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,27 @@ function App() {
     setPivots(prev => [pivot, ...prev])
   }
 
+  const handleUpdateWheel = (wheel: Wheel) => {
+    const message = `Update Wheel at (${wheel.center.x.toFixed(1)}, ${wheel.center.y.toFixed(1)})`;
+    console.log(message);
+    setHistory(prev => [{ message, timestamp: new Date() }, ...prev]);
+    setWheels(prev => prev.map(w => w.id === wheel.id ? wheel : w));
+  }
+
+  const handleUpdateRod = (rod: Rod) => {
+    const message = `Update Rod from (${rod.start.x.toFixed(1)}, ${rod.start.y.toFixed(1)}) to (${rod.end.x.toFixed(1)}, ${rod.end.y.toFixed(1)})`;
+    console.log(message);
+    setHistory(prev => [{ message, timestamp: new Date() }, ...prev]);
+    setRods(prev => prev.map(r => r.id === rod.id ? rod : r));
+  }
+
+  const handleUpdatePivot = (pivot: Pivot) => {
+    const message = `Update Pivot at (${pivot.position.x.toFixed(1)}, ${pivot.position.y.toFixed(1)})`;
+    console.log(message);
+    setHistory(prev => [{ message, timestamp: new Date() }, ...prev]);
+    setPivots(prev => prev.map(p => p.id === pivot.id ? pivot : p));
+  }
+
   const handleDeleteAll = () => {
     const message = 'Delete all elements';
     console.log(message);
@@ -75,6 +96,9 @@ function App() {
           onAddWheel={handleAddWheel}
           onAddRod={handleAddRod}
           onAddPivot={handleAddPivot}
+          onUpdateWheel={handleUpdateWheel}
+          onUpdateRod={handleUpdateRod}
+          onUpdatePivot={handleUpdatePivot}
         />
       </div>
 

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -26,6 +26,9 @@ interface CanvasProps {
   onAddWheel: (wheel: Wheel) => void;
   onAddRod: (rod: Rod) => void;
   onAddPivot: (pivot: Pivot) => void;
+  onUpdateWheel: (wheel: Wheel) => void;
+  onUpdateRod: (rod: Rod) => void;
+  onUpdatePivot: (pivot: Pivot) => void;
 }
 
 // Hit testing functions
@@ -101,6 +104,9 @@ export const Canvas = ({
   onAddWheel,
   onAddRod,
   onAddPivot,
+  onUpdateWheel,
+  onUpdateRod,
+  onUpdatePivot,
 }: CanvasProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [isDrawing, setIsDrawing] = useState(false);

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -324,38 +324,59 @@ export const Canvas = ({
         const wheel = selectionState.originalElement as Wheel;
         if (selectionState.dragType === 'wheel-center') {
           // Move wheel center
-          onUpdateWheel({
+          const updatedWheel = {
             ...wheel,
             center: {
               x: wheel.center.x + dx,
               y: wheel.center.y + dy,
             },
-          });
+          };
+          onUpdateWheel(updatedWheel);
+          // Update the original element with the new position
+          setSelectionState(prev => ({
+            ...prev,
+            originalElement: updatedWheel,
+            dragStartPoint: point,
+          }));
         } else if (selectionState.dragType === 'wheel-edge') {
           // Resize wheel
           const newRadius = Math.sqrt(
             (point.x - wheel.center.x) ** 2 + (point.y - wheel.center.y) ** 2
           );
-          onUpdateWheel({
+          const updatedWheel = {
             ...wheel,
             radius: newRadius,
-          });
+          };
+          onUpdateWheel(updatedWheel);
+          // Update the original element with the new radius
+          setSelectionState(prev => ({
+            ...prev,
+            originalElement: updatedWheel,
+            dragStartPoint: point,
+          }));
         }
       } else if (selectionState.selectionType === 'rod' && selectionState.originalElement) {
         const rod = selectionState.originalElement as Rod;
         if (selectionState.dragType === 'rod-end') {
           // Move rod endpoint
           const isStart = isPointNearPoint(selectionState.dragStartPoint, rod.start);
-          onUpdateRod({
+          const updatedRod = {
             ...rod,
             [isStart ? 'start' : 'end']: {
               x: point.x,
               y: point.y,
             },
-          });
+          };
+          onUpdateRod(updatedRod);
+          // Update the original element with the new position
+          setSelectionState(prev => ({
+            ...prev,
+            originalElement: updatedRod,
+            dragStartPoint: point,
+          }));
         } else if (selectionState.dragType === 'rod-middle') {
           // Move entire rod
-          onUpdateRod({
+          const updatedRod = {
             ...rod,
             start: {
               x: rod.start.x + dx,
@@ -365,25 +386,33 @@ export const Canvas = ({
               x: rod.end.x + dx,
               y: rod.end.y + dy,
             },
-          });
+          };
+          onUpdateRod(updatedRod);
+          // Update the original element with the new position
+          setSelectionState(prev => ({
+            ...prev,
+            originalElement: updatedRod,
+            dragStartPoint: point,
+          }));
         }
       } else if (selectionState.selectionType === 'pivot' && selectionState.originalElement) {
         const pivot = selectionState.originalElement as Pivot;
         // Move pivot
-        onUpdatePivot({
+        const updatedPivot = {
           ...pivot,
           position: {
             x: pivot.position.x + dx,
             y: pivot.position.y + dy,
           },
-        });
+        };
+        onUpdatePivot(updatedPivot);
+        // Update the original element with the new position
+        setSelectionState(prev => ({
+          ...prev,
+          originalElement: updatedPivot,
+          dragStartPoint: point,
+        }));
       }
-      
-      // Update drag start point
-      setSelectionState(prev => ({
-        ...prev,
-        dragStartPoint: point,
-      }));
     }
   }, [isDrawing, startPoint, selectedTool, selectionState, onUpdateWheel, onUpdateRod, onUpdatePivot]);
 

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -178,17 +178,35 @@ export const Canvas = ({
 
     // Draw rods
     rods.forEach(rod => {
+      // Draw the main line
       ctx.beginPath();
       ctx.moveTo(rod.start.x, rod.start.y);
       ctx.lineTo(rod.end.x, rod.end.y);
       ctx.stroke();
+
+      // Draw circular endpoints
+      const endpointRadius = 4;
+      ctx.beginPath();
+      ctx.arc(rod.start.x, rod.start.y, endpointRadius, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.beginPath();
+      ctx.arc(rod.end.x, rod.end.y, endpointRadius, 0, Math.PI * 2);
+      ctx.fill();
     });
 
     // Draw pivots
     pivots.forEach(pivot => {
       ctx.beginPath();
-      ctx.arc(pivot.position.x, pivot.position.y, 5, 0, Math.PI * 2);
+      ctx.arc(pivot.position.x, pivot.position.y, 6, 0, Math.PI * 2);
+      ctx.fillStyle = 'black';
       ctx.fill();
+      // Add a white border to make it more visible
+      ctx.strokeStyle = 'white';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+      // Reset styles
+      ctx.strokeStyle = 'black';
+      ctx.lineWidth = 2;
     });
 
     // Draw preview for rod being drawn

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -26,9 +26,9 @@ interface CanvasProps {
   onAddWheel: (wheel: Wheel) => void;
   onAddRod: (rod: Rod) => void;
   onAddPivot: (pivot: Pivot) => void;
-  onUpdateWheel: (wheel: Wheel) => void;
-  onUpdateRod: (rod: Rod) => void;
-  onUpdatePivot: (pivot: Pivot) => void;
+  onUpdateWheel: (wheel: Wheel, isDragComplete?: boolean) => void;
+  onUpdateRod: (rod: Rod, isDragComplete?: boolean) => void;
+  onUpdatePivot: (pivot: Pivot, isDragComplete?: boolean) => void;
 }
 
 // Hit testing functions
@@ -349,7 +349,7 @@ export const Canvas = ({
               y: wheel.center.y + dy,
             },
           };
-          onUpdateWheel(updatedWheel);
+          onUpdateWheel(updatedWheel, false);
           // Update the original element with the new position
           setSelectionState(prev => ({
             ...prev,
@@ -365,7 +365,7 @@ export const Canvas = ({
             ...wheel,
             radius: newRadius,
           };
-          onUpdateWheel(updatedWheel);
+          onUpdateWheel(updatedWheel, false);
           // Update the original element with the new radius
           setSelectionState(prev => ({
             ...prev,
@@ -385,7 +385,7 @@ export const Canvas = ({
               y: point.y,
             },
           };
-          onUpdateRod(updatedRod);
+          onUpdateRod(updatedRod, false);
           // Update the original element with the new position
           setSelectionState(prev => ({
             ...prev,
@@ -405,7 +405,7 @@ export const Canvas = ({
               y: rod.end.y + dy,
             },
           };
-          onUpdateRod(updatedRod);
+          onUpdateRod(updatedRod, false);
           // Update the original element with the new position
           setSelectionState(prev => ({
             ...prev,
@@ -423,7 +423,7 @@ export const Canvas = ({
             y: pivot.position.y + dy,
           },
         };
-        onUpdatePivot(updatedPivot);
+        onUpdatePivot(updatedPivot, false);
         // Update the original element with the new position
         setSelectionState(prev => ({
           ...prev,
@@ -447,7 +447,16 @@ export const Canvas = ({
       setIsDrawing(false);
       setStartPoint(null);
       setCurrentPoint(null);
-    } else if (selectedTool === 'select') {
+    } else if (selectedTool === 'select' && selectionState.originalElement) {
+      // Log the final position when drag is complete
+      if (selectionState.selectionType === 'wheel') {
+        onUpdateWheel(selectionState.originalElement as Wheel, true);
+      } else if (selectionState.selectionType === 'rod') {
+        onUpdateRod(selectionState.originalElement as Rod, true);
+      } else if (selectionState.selectionType === 'pivot') {
+        onUpdatePivot(selectionState.originalElement as Pivot, true);
+      }
+      
       // Clear selection state
       setSelectionState({
         selectedId: null,
@@ -457,7 +466,7 @@ export const Canvas = ({
         originalElement: null,
       });
     }
-  }, [isDrawing, startPoint, selectedTool, onAddRod]);
+  }, [isDrawing, startPoint, selectedTool, selectionState, onAddRod, onUpdateWheel, onUpdateRod, onUpdatePivot]);
 
   return (
     <CanvasContainer>

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -28,4 +28,16 @@ export interface DrawingState {
   pivots: Pivot[];
   selectedTool: Tool;
   selectedElement: string | null;
+}
+
+// New types for selection and dragging
+export type SelectionType = 'wheel' | 'rod' | 'pivot' | null;
+export type DragType = 'wheel-center' | 'wheel-edge' | 'rod-end' | 'rod-middle' | 'pivot' | null;
+
+export interface SelectionState {
+  selectedId: string | null;
+  selectionType: SelectionType;
+  dragType: DragType;
+  dragStartPoint: Point | null;
+  originalElement: Wheel | Rod | Pivot | null;
 } 

--- a/system-prompt.txt
+++ b/system-prompt.txt
@@ -7,10 +7,12 @@ Thank you for contributing to this software project. Before we start, please rea
 
 Thank you!
 
-I am about to give you a coding task that you should implement. HOWEVER, as mentioned in CONTRIBUTING.md, before you implement it, please first copy my prompt into a file in the `prompts/` directory. This is for auditing purposes. The filename should have the form `YYYY-MM-DD-HH-MM-SS_BRANCH_NAME.txt`, where `BRANCH_NAME` is the name of the git branch you'll create for this task / feature. (You may need to run `date` in a terminal to determine the current date & time.) Add this prompt file in your first commit on this new branch. For example, if the coding task is "Please add multi-select functionality to the app, with behavior as follows ...", then you should create the text file `prompts/2025-05-31-15-43-11_addMultiSelect.txt` with the content "Please add multi-select functionality to the app, with behavior as follows ...", copied EXACTLY. Then create and checkout the git branch `addMultiSelect`. Then add and commit the file `prompts/2025-05-31-15-43-11_addMultiSelect.txt` to that git branch. THEN you can proceed to implement your coding solution.
+I am about to give you a coding task that you should implement. HOWEVER, as mentioned in CONTRIBUTING.md, before you implement it, please first copy my prompt into a file in the `prompts/` directory. This is for auditing purposes. The filename should have the form `YYYY-MM-DD-HH-MM-SS_BRANCH_NAME.txt`, where `BRANCH_NAME` is the name of the git branch you'll create for this task / feature. (You may need to run `date` in a terminal to determine the current date & time.) Add this prompt file in your first commit on this new branch.
+
+For example, if the coding task is "Please add multi-select functionality to the app, with behavior as follows ...", then you should create the text file `prompts/2025-05-31-15-43-11_addMultiSelect.txt` with the content "Please add multi-select functionality to the app, with behavior as follows ...", copied EXACTLY. Then create and checkout the git branch `addMultiSelect`. Then add and commit the file `prompts/2025-05-31-15-43-11_addMultiSelect.txt` to that git branch. THEN you can proceed to implement your coding solution.
 
 In your implementation, use small atomic commits. If I give you a list of changes to make, each should be in its own commit.
 
-When it's time to make a Pull Request, use the `gh` command (github CLI) to create the PR.
+Lastly: After implementation, when it's time to make a Pull Request, use the `gh` command (github CLI) to create the PR. To avoid newline formatting issues, write the PR description to a file and use the `--body-file` option.
 
 Does this make sense? If so, I will proceed to give you a coding task, which you will then copy verbatim into a file as described above.


### PR DESCRIPTION
*Note: this PR description was composed by AI.*

This PR implements the Select tool functionality for dragging and resizing elements on the canvas. The changes include:

1. Selection and Hit Testing:
   - Added hit testing for wheels, rods, and pivots
   - Implemented different drag types (center, edge, end, middle)
   - Added selection state management

2. Drag Functionality:
   - Wheel movement: drag center to move, drag edge to resize
   - Rod movement: drag ends to change endpoints, drag middle to move
   - Pivot movement: drag to reposition

3. Visual Improvements:
   - Added circular endpoints to rods for better interaction
   - Improved pivot visibility with white border
   - Fixed wheel dragging jitter

4. UX Improvements:
   - Reduced console noise by only logging on drag complete
   - History table now shows one entry per drag operation
   - Smooth visual updates during dragging

The changes are split into logical commits:
1. Add types for selection and dragging state
2. Add hit testing functions for selection
3. Add handlers for updating elements during drag
4. Implement drag functionality for elements
5. Fix wheel dragging jitter
6. Add circular endpoints to rods and improve pivot visibility
7. Only log updates when drag is complete 