### PR TITLE
Add Cursor Rules for Feature Workflow

### DIFF
--- a/.cursor/rules/feature_workflow.md
+++ b/.cursor/rules/feature_workflow.md
@@ -1,0 +1,42 @@
+# Feature Workflow Process
+
+This rule defines the process to follow when implementing a new feature in this project.
+
+## Initial Setup
+
+1. When receiving a new feature request:
+   - Get current timestamp using `date` command
+   - Create a new branch with appropriate name (e.g., `addMultiSelect`)
+   - Create prompt file in `prompts/` with format: `YYYY-MM-DD-HH-MM-SS_BRANCH_NAME.txt`
+   - Copy the feature request prompt verbatim into this file
+   - Make initial commit with message: "FEATURE PROMPT: <one-line summary>"
+
+## Implementation Process
+
+1. Make small atomic commits for each logical change
+2. Write commit messages to `commit-message.txt` to avoid newline issues
+3. Follow conventional commits format:
+   - feat: new feature
+   - fix: bug fix
+   - docs: documentation changes
+   - style: formatting changes
+   - refactor: code restructuring
+   - perf: performance improvements
+   - test: test additions/modifications
+   - chore: build/auxiliary changes
+   - ci: CI configuration changes
+
+## Pull Request Process
+
+1. Use GitHub CLI (`gh`) to create PR
+2. Write PR description to `pr-body.txt`
+3. Use `--body-file` option when creating PR
+4. Include disclaimer: "*Note: this PR description was composed by AI.*"
+
+## Additional Guidelines
+
+- Follow test-driven development when applicable
+- Ensure all tests pass before each commit
+- Use eslint for code quality checks
+- Follow semantic versioning (MAJOR.MINOR.PATCH)
+- Use rebase-based git workflow 

--- a/.cursor/rules/git_auto_commit.md
+++ b/.cursor/rules/git_auto_commit.md
@@ -1,0 +1,63 @@
+---
+description: Git Auto Commit Rule
+globs: 
+alwaysApply: false
+---
+## Description
+This rule ensures that after Cursor IDE automatically performs changes from Git commits, the modified files are automatically committed back to Git using the conventional commit format. This maintains a clear and consistent commit history that explains what changes were made and why.
+
+## Rule
+After Cursor IDE performs automatic changes:
+1. All modified files MUST be automatically committed
+2. Commit messages MUST follow the conventional commit format
+3. Commit messages MUST include:
+   - Type: The type of change (feat, fix, docs, style, refactor, test, chore)
+   - Scope: The affected component or area (optional)
+   - Description: A clear explanation of what changed
+   - Body: Detailed explanation of why the changes were made
+4. The commit message MUST reference the original prompts used to generate the changes
+
+## Implementation
+- The Cursor IDE will:
+  - Track all files modified by automatic changes
+  - Generate a conventional commit message based on the changes
+  - Include the original prompts in the commit body
+  - Automatically execute the git commit command
+  - Handle any potential merge conflicts or errors
+
+## Benefits
+- Maintains clear and consistent commit history
+- Provides traceability between prompts and code changes
+- Follows industry-standard commit conventions
+- Automates the commit process for better workflow efficiency
+
+## Examples
+✅ Correct Commit Message:
+```
+feat(ide): implement automatic code formatting
+
+- Added automatic formatting for Python files
+- Implemented consistent indentation rules
+- Added support for line length limits
+
+Changes were generated based on the following prompts:
+1. "Format the code according to PEP 8 standards"
+2. "Ensure consistent indentation across all files"
+```
+
+❌ Incorrect Commit Message:
+```
+Updated some files
+
+- Made changes to formatting
+- Fixed some issues
+```
+
+## Conventional Commit Types
+- feat: New feature
+- fix: Bug fix
+- docs: Documentation changes
+- style: Code style changes (formatting, etc.)
+- refactor: Code refactoring
+- test: Adding or modifying tests
+- chore: Maintenance tasks

--- a/.cursor/rules/mdc_rules_location.md
+++ b/.cursor/rules/mdc_rules_location.md
@@ -1,0 +1,46 @@
+---
+description: Cursor Rules Location Rule
+globs: *.mdc
+alwaysApply: false
+---
+## Description
+This rule ensures that all new MDC (Model-Driven Code) rules are created in the `.cursor/rules` directory, maintaining a consistent and organized structure for rule management.
+
+## Rule
+When creating new MDC rules:
+1. All new MDC rules MUST be created in the `.cursor/rules` directory
+2. Each rule MUST be in a separate file
+3. Rule files MUST use the `.mdc` extension
+4. Rule files MUST follow the naming convention: `[rule-name].mdc`
+5. Rule files MUST contain proper markdown formatting
+
+## Implementation
+- The Cursor IDE will enforce this rule by:
+  - Automatically creating new MDC rules in the `.cursor/rules` directory
+  - Preventing creation of MDC rules outside this directory
+  - Maintaining separation of rules into individual files
+  - Ensuring proper file extensions and naming conventions
+
+## Benefits
+- Improved organization and maintainability
+- Easier rule discovery and management
+- Consistent rule structure across the project
+- Better version control and tracking of rule changes
+
+## Examples
+✅ Correct:
+```
+.cursor/rules/
+  ├── mdc-rules-location.mdc
+  ├── another-rule.mdc
+  └── third-rule.mdc
+```
+
+❌ Incorrect:
+```
+.cursor/
+  ├── rules/
+  │   └── mdc-rules-location.mdc
+  └── other-rules/
+      └── another-rule.mdc
+```


### PR DESCRIPTION
This PR adds some Cursor "rules" to guide Cursor's behavior.

- Docs on Rules: https://docs.cursor.com/context/rules
- I learned about rules from https://ghuntley.com/stdlib/ and https://ghuntley.com/specs/ .
- I got a couple rules from https://github.com/ghuntley/groundhog/blob/trunk/.cursor/rules/
- I'm also experimenting with using my `system-prompt.txt` as a rule, which I converted to a rule by simply asking Cursor (see the Rules docs for details)

From https://ghuntley.com/stdlib/ :

"""
My instructions to the composer roughly follow the following steps:

1. A lengthy discussion about requirements and listing the requirements out in numbered bullet points so that I can cite the specific requirement when something needs changing or if something goes wrong.
2. Asking cursor to write the requirements to a file, that I can reinject back in to the context window if required.
3. Attaching the @file and @file-test into the context. Specifically instructing Cursor to "inspect and describe the file"
4. Asking the agent to implement the "XYZ" requirement, author tests and documentation.
5. Run builds and tests after each change.
6. Perform a git commit (via a configured rule) if everything went all right.

You can ask Cursor to write rules. When Cursor gets it right after intervention, ask it to author a rule or update a rule with its learnings.
"""
